### PR TITLE
Fix: remove static destructors that decrement the Python object reference counts

### DIFF
--- a/src/clp_ffi_py/PyObjectUtils.hpp
+++ b/src/clp_ffi_py/PyObjectUtils.hpp
@@ -18,6 +18,17 @@ public:
     void operator()(PyObjectType* ptr) { Py_XDECREF(reinterpret_cast<PyObject*>(ptr)); }
 };
 
+
+/**
+ * A Python empty deleter that does nothing designed for the global pointers.
+ * @tparam PyObjectType
+ */
+template <typename PyObjectType>
+class PyObjectEmptyDeleter {
+public:
+    void operator()(PyObjectType* ptr) {}
+};
+
 /**
  * A type of smart pointer that maintains a reference to a Python object for the
  * duration of its lifetime.
@@ -25,5 +36,8 @@ public:
  */
 template <typename PyObjectType>
 using PyObjectPtr = std::unique_ptr<PyObjectType, PyObjectDeleter<PyObjectType>>;
+
+template <typename PyObjectType>
+using PyObjectGlobalPtr = std::unique_ptr<PyObjectType, PyObjectEmptyDeleter<PyObjectType>>;
 }  // namespace clp_ffi_py
 #endif  // CLP_FFI_PY_PY_OBJECT_PTR_HPP

--- a/src/clp_ffi_py/Py_utils.cpp
+++ b/src/clp_ffi_py/Py_utils.cpp
@@ -7,10 +7,10 @@
 namespace clp_ffi_py {
 namespace {
 constexpr char const* const cPyFuncNameGetFormattedTimestamp{"get_formatted_timestamp"};
-PyObjectPtr<PyObject> Py_func_get_formatted_timestamp;
+PyObjectGlobalPtr<PyObject> Py_func_get_formatted_timestamp;
 
 constexpr char const* const cPyFuncNameGetTimezoneFromTimezoneId{"get_timezone_from_timezone_id"};
-PyObjectPtr<PyObject> Py_func_get_timezone_from_timezone_id;
+PyObjectGlobalPtr<PyObject> Py_func_get_timezone_from_timezone_id;
 
 /**
  * Wrapper of PyObject_CallObject.

--- a/src/clp_ffi_py/ir/native/PyDecoder.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoder.cpp
@@ -92,7 +92,7 @@ PyType_Spec PyDecoder_type_spec{
 };
 }  // namespace
 
-PyObjectPtr<PyTypeObject> PyDecoder::m_py_type{nullptr};
+PyObjectGlobalPtr<PyTypeObject> PyDecoder::m_py_type{nullptr};
 
 auto PyDecoder::module_level_init(PyObject* py_module) -> bool {
     static_assert(std::is_trivially_destructible<PyDecoder>());

--- a/src/clp_ffi_py/ir/native/PyDecoder.hpp
+++ b/src/clp_ffi_py/ir/native/PyDecoder.hpp
@@ -25,7 +25,7 @@ public:
 private:
     PyObject_HEAD;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
+    static PyObjectGlobalPtr<PyTypeObject> m_py_type;
 };
 }  // namespace clp_ffi_py::ir::native
 

--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
@@ -362,8 +362,8 @@ auto PyDecoderBuffer::test_streaming(uint32_t seed) -> PyObject* {
     );
 }
 
-PyObjectPtr<PyTypeObject> PyDecoderBuffer::m_py_type{nullptr};
-PyObjectPtr<PyObject> PyDecoderBuffer::m_py_incomplete_stream_error{nullptr};
+PyObjectGlobalPtr<PyTypeObject> PyDecoderBuffer::m_py_type{nullptr};
+PyObjectGlobalPtr<PyObject> PyDecoderBuffer::m_py_incomplete_stream_error{nullptr};
 
 auto PyDecoderBuffer::get_py_type() -> PyTypeObject* {
     return m_py_type.get();

--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.hpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.hpp
@@ -236,8 +236,8 @@ private:
     size_t m_num_decoded_message;
     bool m_py_buffer_protocol_enabled;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
-    static PyObjectPtr<PyObject> m_py_incomplete_stream_error;
+    static PyObjectGlobalPtr<PyTypeObject> m_py_type;
+    static PyObjectGlobalPtr<PyObject> m_py_incomplete_stream_error;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif

--- a/src/clp_ffi_py/ir/native/PyFourByteEncoder.cpp
+++ b/src/clp_ffi_py/ir/native/PyFourByteEncoder.cpp
@@ -151,7 +151,7 @@ PyType_Spec PyFourByteEncoder_type_spec{
 };
 }  // namespace
 
-PyObjectPtr<PyTypeObject> PyFourByteEncoder::m_py_type{nullptr};
+PyObjectGlobalPtr<PyTypeObject> PyFourByteEncoder::m_py_type{nullptr};
 
 auto PyFourByteEncoder::module_level_init(PyObject* py_module) -> bool {
     static_assert(std::is_trivially_destructible<PyFourByteEncoder>());

--- a/src/clp_ffi_py/ir/native/PyFourByteEncoder.hpp
+++ b/src/clp_ffi_py/ir/native/PyFourByteEncoder.hpp
@@ -26,7 +26,7 @@ public:
 private:
     PyObject_HEAD;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
+    static PyObjectGlobalPtr<PyTypeObject> m_py_type;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif

--- a/src/clp_ffi_py/ir/native/PyLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyLogEvent.cpp
@@ -637,7 +637,7 @@ auto PyLogEvent::init(
     return true;
 }
 
-PyObjectPtr<PyTypeObject> PyLogEvent::m_py_type{nullptr};
+PyObjectGlobalPtr<PyTypeObject> PyLogEvent::m_py_type{nullptr};
 
 auto PyLogEvent::get_py_type() -> PyTypeObject* {
     return m_py_type.get();

--- a/src/clp_ffi_py/ir/native/PyLogEvent.hpp
+++ b/src/clp_ffi_py/ir/native/PyLogEvent.hpp
@@ -154,7 +154,7 @@ private:
     LogEvent* m_log_event;
     PyMetadata* m_py_metadata;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
+    static PyObjectGlobalPtr<PyTypeObject> m_py_type;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif  // CLP_FFI_PY_PY_LOG_EVENT_HPP

--- a/src/clp_ffi_py/ir/native/PyMetadata.cpp
+++ b/src/clp_ffi_py/ir/native/PyMetadata.cpp
@@ -263,7 +263,7 @@ auto PyMetadata::init_py_timezone() -> bool {
     return true;
 }
 
-PyObjectPtr<PyTypeObject> PyMetadata::m_py_type{nullptr};
+PyObjectGlobalPtr<PyTypeObject> PyMetadata::m_py_type{nullptr};
 
 auto PyMetadata::get_py_type() -> PyTypeObject* {
     return m_py_type.get();

--- a/src/clp_ffi_py/ir/native/PyMetadata.hpp
+++ b/src/clp_ffi_py/ir/native/PyMetadata.hpp
@@ -117,7 +117,7 @@ private:
     Metadata* m_metadata;
     PyObject* m_py_timezone;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
+    static PyObjectGlobalPtr<PyTypeObject> m_py_type;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif  // CLP_FFI_PY_PY_METADATA_HPP

--- a/src/clp_ffi_py/ir/native/PyQuery.cpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.cpp
@@ -692,8 +692,8 @@ auto PyQuery::init(
     return true;
 }
 
-PyObjectPtr<PyTypeObject> PyQuery::m_py_type{nullptr};
-PyObjectPtr<PyObject> PyQuery::m_py_wildcard_query_type{nullptr};
+PyObjectGlobalPtr<PyTypeObject> PyQuery::m_py_type{nullptr};
+PyObjectGlobalPtr<PyObject> PyQuery::m_py_wildcard_query_type{nullptr};
 
 auto PyQuery::get_py_type() -> PyTypeObject* {
     return m_py_type.get();

--- a/src/clp_ffi_py/ir/native/PyQuery.hpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.hpp
@@ -82,8 +82,8 @@ private:
     PyObject_HEAD;
     Query* m_query;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
-    static PyObjectPtr<PyObject> m_py_wildcard_query_type;
+    static PyObjectGlobalPtr<PyTypeObject> m_py_type;
+    static PyObjectGlobalPtr<PyObject> m_py_wildcard_query_type;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif


### PR DESCRIPTION
The static destructors of the Python objects (such as Py types and exceptions) will attempt to decrease the reference count when the process exits. However, its behavior is undefined due to the following reasons, which was first exposed in Python 3.10.12 with a segfault on exit:
1. the Python interpreter can exit before the global/static destructors execute. Accessing the reference count is illegal if the interpreter is already shut down. There is no way to guarantee the ordering of the execution for the interpreter cleanup and the global/static destructors.
2. C++ RAII guarantees that some code will execute when the scope exits, but it doesn't guarantee that all of said code finishes executing; the process may exit before the RAII destructor is complete.

This PR fixes the problem by making all the global/static Pyobject pointers trivially destructible. This means it will not attempt to release any resources when `reset` or destruction happens, which can lead to potential memory leaks. However, according to the current use case, this is acceptable since the only expected execution of the trivial destructor is on process exit. We keep using smart ptr just to protect the underlying raw pointers from being exposed and accidentally modified.  